### PR TITLE
feat: Add `plop` docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,39 @@ pnpm add @plyaz/ui
 ```bash
 pnpm run storybook
 ```
+
+## Plop Utility for Auto-Generating Storybook Stories
+
+### Requirement
+
+Manually creating Storybook story files for each component can be repetitive. So we needed a way to automatically generate story files with consistent structure and boilerplate.
+
+### Solution
+
+We integrated the **Plop** library, a micro-generator framework that automates file creation using custom templates (in our case, a story template). With Plop, we can generate story files for components quickly and consistently.
+
+### How It Works
+
+Plop takes three inputs and generates a story file based on a defined template:
+
+- **Path to the component:** The target path where the file should be generated (relative to src/)
+- **Component directory name (PascalCase):** The component directory name (e.g., Button)
+- **Component name (PascalCase):** The component name in PascalCase format based on these inputs, Plop processes a predefined template plop-templates/Component.stories.tsx.hbs file and generates the corresponding story file in the specified location.
+
+**Plop** then executes a custom template file and generates the new story file at the target path with the provided name.
+
+### Folder Structure
+
+```
+plopfile.js
+/plop-templates
+└── Component.stories.tsx.hbs # template for story file
+```
+
+### Usage
+
+To generate a new story file:
+
+```bash
+pnpm run generate
+```


### PR DESCRIPTION
## PR Summary
Added a light documentation for the `plop` library to `README.md` for other devs' guidance.

## Checklist
- Updated the README with `Plop Utility for Auto-Generating Storybook Stories`

## Tests
N/A

## Results
<img width="835" alt="image" src="https://github.com/user-attachments/assets/25432986-4761-4a39-809e-141543478dcd" />
