### PR TITLE
fix: Fixed  conflicts between prettier and eslint-tailwind-classes-pl…

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "pnpm": ">=8.0.0"
   },
   "dependencies": {
-    "@plyaz/devtools": "^1.7.0",
+    "@plyaz/devtools": "^1.7.2",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@plyaz/devtools':
-        specifier: ^1.7.0
-        version: 1.7.0(eab7f0d77d3b50312a5ec47140474ff6)
+        specifier: ^1.7.2
+        version: 1.7.2(eab7f0d77d3b50312a5ec47140474ff6)
       '@radix-ui/react-select':
         specifier: ^2.2.5
         version: 2.2.5(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -957,8 +957,8 @@ packages:
     resolution: {integrity: sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@plyaz/devtools@1.7.0':
-    resolution: {integrity: sha512-FNFwlFaTFTMZq/P/K1kj5DIsVON+FCI/rKqStiJJ1TUL87tEzVRg2q1bXQGydV2LLPSkhd7NcCQX4mABPewNxA==}
+  '@plyaz/devtools@1.7.2':
+    resolution: {integrity: sha512-TnX/Q8MZKUDJAg47xRnAsq1NlXRkjbw+k6xXtCHiDm83X1jnypJj5hwRe5eNwu3ZXBYs0NAUILh/7Ldk65UtBA==}
     peerDependencies:
       '@darraghor/eslint-plugin-nestjs-typed': ^6.6.0
       '@typescript-eslint/eslint-plugin': ^8.0.0
@@ -7778,7 +7778,7 @@ snapshots:
 
   '@pkgr/core@0.2.7': {}
 
-  '@plyaz/devtools@1.7.0(eab7f0d77d3b50312a5ec47140474ff6)':
+  '@plyaz/devtools@1.7.2(eab7f0d77d3b50312a5ec47140474ff6)':
     dependencies:
       '@darraghor/eslint-plugin-nestjs-typed': 6.7.0(@typescript-eslint/parser@8.36.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(class-validator@0.14.2)(eslint-import-resolver-typescript@3.10.1)(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/eslint-plugin': 8.36.0(@typescript-eslint/parser@8.36.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -53,9 +53,10 @@ const config: Record<string, unknown> = {
       fileName: (format: string) => `ui.${format}.js`,
       formats: ['es', 'cjs'],
     },
-   rollupOptions: {
-      external: ['react', 
-        'react-dom', 
+    rollupOptions: {
+      external: [
+        'react',
+        'react-dom',
         'next-intl',
         'react/jsx-runtime',
         'react/jsx-dev-runtime',


### PR DESCRIPTION
# Removed Conflicts between Prettier and Eslint tailwind classes 

## Issues

- [x] **Tailwind class sorting conflict:** Prettier and the ESLint Tailwind plugin both try to sort Tailwind classes in their own way, which causes conflicts and leads to warnings.
- [x] **Multiline formatting conflict:** Prettier wraps class names based on printWidth and tabWidth, while the ESLint Tailwind plugin applies its own rules for breaking classes into multiple lines. This mismatch causes formatting conflicts and warnings.

## Type of Change

- [x]  🐛 Bug fix (non-breaking change that fixes an issue)
- [x]  🔨 Refactoring (code improvement with no functional changes)

### 1. Implementation 

- [x] Disable the `better-tailwindcss/sort-classes` rule in @plyaz/devtools and configure it locally within this project as needed.
- [x] Disable the `better-tailwindcss/multiline` rule in @plyaz/devtools and manage it directly in this project for better control.
### 1. Reference 
 - [x] This [link](https://stackoverflow.com/questions/75712335/prettier-wont-auto-fix-longer-tailwind-css-class-name-stack-according-to-print) clearly explains that Prettier does not currently support consistent multiline formatting for Tailwind CSS classes
 **@plyaz/devtools commits**
 - [x] https://github.com/Plyaz-Official/devtools/commit/5cf86dab5fc457774ff8447a9fca3e4c24fc3a53
 - [x] https://github.com/Plyaz-Official/devtools/commit/1e03622150f67d9f00d8c52c7096d85ceafbf525
 
### 1.Results

 - [x] Class sorting warnings appeared before disabling the `better-tailwindcss/sort-classes rule`.
<img width="851" height="290" alt="image" src="https://github.com/user-attachments/assets/248953e1-e43a-41a5-9b6f-c9ca233d3fb4" />

 - [x] Class sorting warnings disappeared after disabling the `better-tailwindcss/sort-classes rule`.
 <img width="851" height="290" alt="image" src="https://github.com/user-attachments/assets/3a44de83-0fba-4965-a02b-fb2a2137ff2e" />

 - [x] Multiline warnings appeared before disabling the `better-tailwindcss/multiline`.
<img width="851" height="290" alt="image" src="https://github.com/user-attachments/assets/14fb23e1-2199-41bb-ae41-ffbc8af9181f" />

 - [x] Multiline warnings disappeard after disabling the `better-tailwindcss/multiline`.
<img width="851" height="290" alt="image" src="https://github.com/user-attachments/assets/d9edcf04-62f1-4297-af59-e688a286db1c" />


